### PR TITLE
Adds stop function to KafkaServer

### DIFF
--- a/src/servers/kafka/index.ts
+++ b/src/servers/kafka/index.ts
@@ -77,6 +77,20 @@ export class KafkaServer extends BaseServer {
       ));
   }
 
+  stop(callback?: ((err: any, data: any) => any) | undefined) {
+    console.log('Disconnecting consumer');
+    this.consumer.disconnect((err) => {
+      if (err) {
+        if (callback) {
+          callback(err, null);
+        }
+        return;
+      }
+      console.log('Disconnecting producer');
+      this.producer.disconnect(callback);
+    });
+  }
+
   private produce(event: KafkaEvent) {
     this.producer.produce(
       // Topic


### PR DESCRIPTION
The `callback` may be "promisified" later for a cleaner code.

Other functions from consumer/producer may also be "promisified" like `connect()` to remove listeners for `ready` and `error`, but that's another PR.