### PR TITLE
Allow initial offset configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { Server } from './server';
 export { KafkaServer, KafkaInputEvent, KafkaOutputEvent } from './kafka';
 // Test helpers
 export { TestServer } from './test-helpers';
+export { InitialOffset } from './kafka/event-consumer';

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -17,6 +17,7 @@ export interface EventConsumerConfig {
   groupId: string;
   broker: string;
   topics: string[];
+  initialOffset: InitialOffset;
 }
 
 export enum InitialOffset {
@@ -41,8 +42,8 @@ export class EventConsumer extends EventEmitter {
     this.config = config;
   }
 
-  start(initialOffset: InitialOffset): void {
-    this.consumerStream = this.createStream(initialOffset);
+  start(): void {
+    this.consumerStream = this.createStream(this.config.initialOffset);
     this.consumerStream.on('error', error => this.emit('error', error));
     this.consumerStream.on('data', (message: ConsumerStreamMessage) => {
       this.dispatch(message);

--- a/src/kafka/kafka-server.ts
+++ b/src/kafka/kafka-server.ts
@@ -1,7 +1,7 @@
 import { Server } from '../server';
 import { Router } from '../router';
 import { OutputEvent } from '../events';
-import { EventConsumer } from './event-consumer';
+import { EventConsumer, InitialOffset } from './event-consumer';
 import { EventProducer } from './event-producer';
 
 export interface KafkaConfig {
@@ -9,6 +9,7 @@ export interface KafkaConfig {
   broker: string;
   consumerTopics: string[];
   producerTopic?: string;
+  initialOffset?: InitialOffset;
 }
 
 export class KafkaServer extends Server {
@@ -30,7 +31,7 @@ export class KafkaServer extends Server {
   }
 
   start() {
-    this.consumer.start();
+    this.consumer.start(this.config.initialOffset || InitialOffset.beginning);
     this.consumer.on('error', error => this.emit('error', error));
     this.producer.start();
     this.producer.on('error', error => this.emit('error', error));

--- a/src/kafka/kafka-server.ts
+++ b/src/kafka/kafka-server.ts
@@ -21,7 +21,8 @@ export class KafkaServer extends Server {
     this.consumer = new EventConsumer(this.router, {
       groupId: this.config.groupId,
       broker: this.config.broker,
-      topics: this.config.consumerTopics
+      topics: this.config.consumerTopics,
+      initialOffset: this.config.initialOffset || InitialOffset.beginning
     });
     this.producer = new EventProducer({
       groupId: this.config.groupId,
@@ -31,7 +32,7 @@ export class KafkaServer extends Server {
   }
 
   start() {
-    this.consumer.start(this.config.initialOffset || InitialOffset.beginning);
+    this.consumer.start();
     this.consumer.on('error', error => this.emit('error', error));
     this.producer.start();
     this.producer.on('error', error => this.emit('error', error));


### PR DESCRIPTION
## Purpose
Sometimes we need to setup a different option for the initial offset, as reading a lot of events from an active topic might be way to memory intensive.
## Solution Approach
Allow configuring the initial offset from the KafkaServer configuration, accepted values are: smallest, earliest, beginning, largest, latest, end, error
