### PR TITLE
[ARCH-4] Configure timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -11,8 +11,6 @@ import { Partition } from './interfaces/partition';
 import { InitialOffset } from './interfaces/initial-offset';
 import { RDKafkaConfiguration } from './interfaces/rdkafka-configuration';
 
-const CONNECT_TIMEOUT = 1000;
-
 export class EventConsumer extends EventEmitter {
   private consumerStream: ConsumerStream;
   private partitions = new Map<number, Partition>();
@@ -59,7 +57,7 @@ export class EventConsumer extends EventEmitter {
       {
         topics: this.config.topics,
         objectMode: true,
-        connectOptions: { timeout: CONNECT_TIMEOUT }
+        connectOptions: { timeout: this.config.connectionTimeout }
       }
     );
     stream.consumer.once('ready', () => {

--- a/src/kafka/event-producer.ts
+++ b/src/kafka/event-producer.ts
@@ -2,15 +2,7 @@ import { createWriteStream, ProducerStream } from 'node-rdkafka';
 import { EventEmitter } from 'events';
 import { KafkaOutputEvent } from './kafka-events';
 import { RDKafkaConfiguration } from './interfaces/rdkafka-configuration';
-
-const FLUSH_TIMEOUT = 2000;
-const CONNECT_TIMEOUT = 1000;
-
-export interface EventProducerConfig {
-  groupId: string;
-  broker: string;
-  defaultTopic?: string;
-}
+import { EventProducerConfig } from './interfaces/event-producer-configuration';
 
 export class EventProducer extends EventEmitter {
   private producerStream: ProducerStream;
@@ -54,7 +46,7 @@ export class EventProducer extends EventEmitter {
         return reject('Producer not connected');
       }
       console.debug('Flushing producer');
-      producer.flush(FLUSH_TIMEOUT, (error) => {
+      producer.flush(this.config.flushTimeout, (error) => {
         if (error) {
           return reject(error);
         }
@@ -73,7 +65,7 @@ export class EventProducer extends EventEmitter {
       {},
       {
         objectMode: true,
-        connectOptions: { timeout: CONNECT_TIMEOUT }
+        connectOptions: { timeout: this.config.connectionTimeout }
       }
     );
     stream.producer.once('ready', () => {

--- a/src/kafka/interfaces/event-consumer-configuration.ts
+++ b/src/kafka/interfaces/event-consumer-configuration.ts
@@ -5,4 +5,5 @@ export interface EventConsumerConfiguration {
   broker: string;
   topics: string[];
   initialOffset: InitialOffset;
+  connectionTimeout: number;
 }

--- a/src/kafka/interfaces/event-producer-configuration.ts
+++ b/src/kafka/interfaces/event-producer-configuration.ts
@@ -1,0 +1,7 @@
+export interface EventProducerConfig {
+  groupId: string;
+  broker: string;
+  defaultTopic?: string;
+  connectionTimeout: number;
+  flushTimeout: number;
+}

--- a/src/kafka/interfaces/kafka-configuration.ts
+++ b/src/kafka/interfaces/kafka-configuration.ts
@@ -6,4 +6,6 @@ export interface KafkaConfiguration {
   consumerTopics: string[];
   producerTopic?: string;
   initialOffset?: InitialOffset;
+  connectionTimeout?: number;
+  flushTimeout?: number;
 }

--- a/src/kafka/kafka-server.ts
+++ b/src/kafka/kafka-server.ts
@@ -6,6 +6,11 @@ import { EventProducer } from './event-producer';
 import { RDKafkaConfiguration } from './interfaces/rdkafka-configuration';
 import { KafkaConfiguration } from './interfaces/kafka-configuration';
 import { InitialOffset } from './interfaces/initial-offset';
+import { EventConsumerConfiguration } from './interfaces/event-consumer-configuration';
+import { EventProducerConfig } from './interfaces/event-producer-configuration';
+
+const DEFAULT_CONNECTION_TIMEOUT = 1000;
+const DEFAULT_FLUSH_TIMEOUT = 2000;
 
 export class KafkaServer extends Server {
   private consumer: EventConsumer;
@@ -36,20 +41,23 @@ export class KafkaServer extends Server {
     return this.producer.produce(event);
   }
 
-  private get consumerConfig() {
+  private get consumerConfig(): EventConsumerConfiguration {
     return {
       groupId: this.config.groupId,
       broker: this.config.broker,
       topics: this.config.consumerTopics,
-      initialOffset: this.config.initialOffset || InitialOffset.beginning
+      initialOffset: this.config.initialOffset || InitialOffset.beginning,
+      connectionTimeout: this.config.connectionTimeout || DEFAULT_CONNECTION_TIMEOUT
     };
   }
 
-  private get producerConfig() {
+  private get producerConfig(): EventProducerConfig {
     return {
       groupId: this.config.groupId,
       broker: this.config.broker,
-      defaultTopic: this.config.producerTopic
+      defaultTopic: this.config.producerTopic,
+      connectionTimeout: this.config.connectionTimeout || DEFAULT_CONNECTION_TIMEOUT,
+      flushTimeout: this.config.flushTimeout || DEFAULT_FLUSH_TIMEOUT
     };
   }
 }


### PR DESCRIPTION
## Purpose

Currently timeouts are fixed, which generates some issues if the connection is not that fast

## Solution Approach

Allow overriding default connection and flush timeouts using the kafka server configuration.