### PR TITLE
[ARCH-27] Allow parallel processing of events

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
     "coverage": "jest --coverage"
   },
   "dependencies": {
+    "config": "^3.0.1",
     "node-rdkafka": "^2.2.1",
     "reflect-metadata": "^0.1.10",
     "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",
+    "@types/config": "^0.0.34",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.2",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -2,7 +2,7 @@ import {
   createReadStream, ConsumerStream, ConsumerStreamMessage
 } from 'node-rdkafka';
 import { Subject } from 'rxjs';
-import { concatMap } from 'rxjs/operators';
+import { concatMap, map } from 'rxjs/operators';
 import { Router } from '../router';
 import { EventEmitter } from 'events';
 import { RawEvent } from '../events';
@@ -78,7 +78,8 @@ export class EventConsumer extends EventEmitter {
   private initPartition(): Partition {
     const observer = new Subject<ConsumerStreamMessage>();
     const subscription = observer.pipe(
-      concatMap(message => this.consume(message))
+      map(message => this.consume(message)),
+      concatMap(result => result)
     ).subscribe(
         message => this.commit(message),
         error => this.emit('error', error)

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -11,9 +11,11 @@ import { Partition } from './interfaces/partition';
 import { InitialOffset } from './interfaces/initial-offset';
 import { RDKafkaConfiguration } from './interfaces/rdkafka-configuration';
 
+const key = ({ topic, partition }: ConsumerStreamMessage) => `${topic}:${partition}`;
+
 export class EventConsumer extends EventEmitter {
   private consumerStream: ConsumerStream;
-  private partitions = new Map<number, Partition>();
+  private partitions = new Map<string, Partition>();
 
   constructor(
     private router: Router,
@@ -39,7 +41,7 @@ export class EventConsumer extends EventEmitter {
   }
 
   dispatch(message: ConsumerStreamMessage) {
-    const partition = this.getPartition(message.partition);
+    const partition = this.getPartition(key(message));
     partition.observer.next(message);
   }
 
@@ -66,11 +68,11 @@ export class EventConsumer extends EventEmitter {
     return stream;
   }
 
-  private getPartition(partitionIdx: number): Partition {
-    let partition = this.partitions.get(partitionIdx);
+  private getPartition(key: string): Partition {
+    let partition = this.partitions.get(key);
     if (!partition) {
       partition = this.initPartition();
-      this.partitions.set(partitionIdx, partition);
+      this.partitions.set(key, partition);
     }
     return partition;
   }

--- a/src/kafka/event-producer.ts
+++ b/src/kafka/event-producer.ts
@@ -9,7 +9,8 @@ export class EventProducer extends EventEmitter {
 
   constructor(
     private config: EventProducerConfig,
-    private rdConfig: RDKafkaConfiguration = {}
+    private rdConfig: RDKafkaConfiguration = {},
+    private logger = config.logger
   ) { super(); }
 
   start(): void {
@@ -45,7 +46,7 @@ export class EventProducer extends EventEmitter {
       if (!producer.isConnected()) {
         return reject('Producer not connected');
       }
-      console.debug('Flushing producer');
+      this.logger.debug('Flushing producer');
       producer.flush(this.config.flushTimeout, (error) => {
         if (error) {
           return reject(error);
@@ -69,7 +70,7 @@ export class EventProducer extends EventEmitter {
       }
     );
     stream.producer.once('ready', () => {
-      console.info('Producer ready');
+      this.logger.info('Producer ready');
     });
     return stream;
   }

--- a/src/kafka/interfaces/event-consumer-configuration.ts
+++ b/src/kafka/interfaces/event-consumer-configuration.ts
@@ -1,6 +1,8 @@
 import { InitialOffset } from './initial-offset';
+import { Logger } from './logger';
 
 export interface EventConsumerConfiguration {
+  logger: Logger;
   groupId: string;
   broker: string;
   topics: string[];

--- a/src/kafka/interfaces/event-producer-configuration.ts
+++ b/src/kafka/interfaces/event-producer-configuration.ts
@@ -1,4 +1,7 @@
+import { Logger } from './logger';
+
 export interface EventProducerConfig {
+  logger: Logger;
   groupId: string;
   broker: string;
   defaultTopic?: string;

--- a/src/kafka/interfaces/kafka-configuration.ts
+++ b/src/kafka/interfaces/kafka-configuration.ts
@@ -1,11 +1,15 @@
 import { InitialOffset } from './initial-offset';
+import { RDKafkaConfiguration } from './rdkafka-configuration';
+import { Logger } from './logger';
 
 export interface KafkaConfiguration {
+  logger: Logger;
   groupId: string;
   broker: string;
   consumerTopics: string[];
-  producerTopic?: string;
-  initialOffset?: InitialOffset;
-  connectionTimeout?: number;
-  flushTimeout?: number;
+  producerTopic: string;
+  initialOffset: InitialOffset;
+  connectionTimeout: number;
+  flushTimeout: number;
+  rdConfig: RDKafkaConfiguration;
 }

--- a/src/kafka/interfaces/logger.ts
+++ b/src/kafka/interfaces/logger.ts
@@ -1,0 +1,5 @@
+export interface Logger {
+  info(val: string): void;
+  debug(val: string): void;
+  error(val: string): void;
+}

--- a/src/kafka/kafka-server.ts
+++ b/src/kafka/kafka-server.ts
@@ -8,20 +8,34 @@ import { KafkaConfiguration } from './interfaces/kafka-configuration';
 import { InitialOffset } from './interfaces/initial-offset';
 import { EventConsumerConfiguration } from './interfaces/event-consumer-configuration';
 import { EventProducerConfig } from './interfaces/event-producer-configuration';
+import { extendConfig } from '../lib/extend-config';
 
-const DEFAULT_CONNECTION_TIMEOUT = 1000;
-const DEFAULT_FLUSH_TIMEOUT = 2000;
+const nullFn = () => { };
+
+const defaultConfig: Partial<KafkaConfiguration> = {
+  logger: {
+    info: nullFn,
+    debug: nullFn,
+    error: nullFn
+  },
+  rdConfig: {},
+  connectionTimeout: 1000,
+  flushTimeout: 2000,
+  initialOffset: InitialOffset.latest
+};
 
 export class KafkaServer extends Server {
   private consumer: EventConsumer;
   private producer: EventProducer;
+  private config: KafkaConfiguration;
 
   constructor(
     router: Router,
-    private config: KafkaConfiguration,
+    config: Partial<KafkaConfiguration>,
     rdConfig: RDKafkaConfiguration = {}
   ) {
     super(router);
+    this.config = extendConfig(config, defaultConfig);
     this.consumer = new EventConsumer(router, this.consumerConfig, rdConfig);
     this.producer = new EventProducer(this.producerConfig, rdConfig);
   }
@@ -43,21 +57,23 @@ export class KafkaServer extends Server {
 
   private get consumerConfig(): EventConsumerConfiguration {
     return {
+      logger: this.config.logger,
       groupId: this.config.groupId,
       broker: this.config.broker,
       topics: this.config.consumerTopics,
-      initialOffset: this.config.initialOffset || InitialOffset.beginning,
-      connectionTimeout: this.config.connectionTimeout || DEFAULT_CONNECTION_TIMEOUT
+      initialOffset: this.config.initialOffset,
+      connectionTimeout: this.config.connectionTimeout
     };
   }
 
   private get producerConfig(): EventProducerConfig {
     return {
+      logger: this.config.logger,
       groupId: this.config.groupId,
       broker: this.config.broker,
       defaultTopic: this.config.producerTopic,
-      connectionTimeout: this.config.connectionTimeout || DEFAULT_CONNECTION_TIMEOUT,
-      flushTimeout: this.config.flushTimeout || DEFAULT_FLUSH_TIMEOUT
+      connectionTimeout: this.config.connectionTimeout,
+      flushTimeout: this.config.flushTimeout
     };
   }
 }

--- a/src/lib/extend-config.ts
+++ b/src/lib/extend-config.ts
@@ -1,0 +1,8 @@
+process.env.SUPPRESS_NO_CONFIG_WARNING = 'y';
+import config = require('config');
+
+export const extendConfig = <A>(configs: Partial<A>, defaultConfig: Partial<A>): A => {
+  config.util.extendDeep(defaultConfig, configs);
+  config.util.setModuleDefaults('event-streamer', defaultConfig);
+  return defaultConfig as A;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,10 @@
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
 
+"@types/config@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@types/config/-/config-0.0.34.tgz#123f91bdb5afdd702294b9de9ca04d9ea11137b0"
+
 "@types/lodash-es@^4.0.0":
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.1.tgz#56745e5411558362aeca31def918f88f725dd29d"
@@ -340,6 +344,12 @@ component-emitter@^1.2.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+config@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/config/-/config-3.0.1.tgz#c3118e2eb45fdfd135277339f87e2492559cb147"
+  dependencies:
+    json5 "^1.0.1"
 
 configstore@^3.0.0:
   version "3.1.2"
@@ -917,6 +927,12 @@ js-yaml@^3.7.0:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
## Purpose

This will allow events to be processed in parallel, while still committing offsets in order when the events are completed (i.e. events will start getting queued if they finish before a previous one and will all be committed when that's done).

This PR also introduces config as a configuration manager, so new services could be configured directly through the config file using the module name (might be useful moving forward to the full framework implementation).

A logger object can now be provided though configuration, if nothing's passed logs will be discarded.

## How to test

I just generated a new microservice, I then created an event that took a large amount of time to process and launched several of those in parallel. I also verified that if one of the middle events failed the program would resume from that after restart, even if newer events had been processed the first time.