### PR TITLE
Fix an issue with latest node-config version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/lib/extend-config.ts
+++ b/src/lib/extend-config.ts
@@ -1,4 +1,5 @@
 process.env.SUPPRESS_NO_CONFIG_WARNING = 'y';
+process.env.ALLOW_CONFIG_MUTATIONS = 'y';
 import config = require('config');
 
 export const extendConfig = <A>(configs: Partial<A>, defaultConfig: Partial<A>): A => {


### PR DESCRIPTION
## Purpose

The latests node-config version have an issue (lorenwest/node-config#329) that prevents us from adding new configurations after the config object was accessed.
## Solution Approach

This workaround allows mutating configurations after they were initialized.