### PR TITLE
Refactor router and TestServer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   roots: ['src/'],
   testRegex: "src(/.*)?/__tests__/[^/]*\\.test\\.(ts)$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  collectCoverage: true,
   collectCoverageFrom: [
     "src/**/*.{ts,js}",
     "!src/**/*.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "3.0.0-alpha16",
+  "version": "3.0.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/__tests__/router.test.ts
+++ b/src/__tests__/router.test.ts
@@ -1,6 +1,6 @@
 import { TestSlowAction } from '../test/factories/test-slow-action';
 import { TestAction } from '../test/factories/test-action';
-import { RouteStrategy } from '../router';
+import { RouteStrategy, Router, Route } from '../router';
 import { testMessage } from '../test/factories/test-message';
 import { testSlowMessage } from '../test/factories/test-slow-message';
 import { testInvalidMessage } from '../test/factories/test-invalid-message';
@@ -60,14 +60,22 @@ describe('Router', () => {
   });
 
   describe('canRoute', () => {
-    it('returns true for known events', () => {
-      const router = testRouter();
-      expect(router.canRoute('TestInputEvent')).toBeTruthy();
+    let router: Router;
+    beforeEach(() => { router = testRouter(); });
+    it('returns false on undefined', () => {
+      expect(router.getRoute()).toBeFalsy();
     });
-
+    it('returns false on empty object', () => {
+      expect(router.getRoute({} as any)).toBeFalsy();
+    });
+    it('returns false on empty code', () => {
+      expect(router.getRoute({ code : '' })).toBeFalsy();
+    });
     it('returns false for unkknown events', () => {
-      const router = testRouter();
-      expect(router.canRoute('TestUnknownEvent')).toBeFalsy();
+      expect(router.getRoute({ code: 'TestUnknownEvent' })).toBeFalsy();
+    });
+    it('returns true for known events', () => {
+      expect(router.getRoute({ code: 'TestInputEvent' })).toBeInstanceOf(Route);
     });
   });
 });

--- a/src/__tests__/test-helpers.test.ts
+++ b/src/__tests__/test-helpers.test.ts
@@ -4,14 +4,28 @@ import { TestOutputAction } from '../test/factories/test-output-action';
 
 describe('TestHelpers', () => {
   describe('TestRouter', () => {
-    it('routes the events', async () => {
+    let server: TestServer;
+    beforeEach(() => {
       const router = new Router();
       router.add(TestInputEvent, TestOutputAction);
+      server = new TestServer(router);
+    });
+
+    it('routes an event', async () => {
       const output = new TestOutputEvent();
       TestOutputAction.outputEvent = output;
-      const server = new TestServer(router);
-      server.input({ code: TestInputEvent.name, value: 'test' });
-      expect(await server.emitted()).toStrictEqual([output]);
+
+      await server.input({ code: TestInputEvent.name, value: 'test' });
+      expect(server.emitted()).toStrictEqual([output]);
+    });
+
+    it('routes multiple events', async () => {
+      const output = new TestOutputEvent();
+      TestOutputAction.outputEvent = output;
+
+      await server.input({ code: TestInputEvent.name, value: 'test' });
+      await server.input({ code: TestInputEvent.name, value: 'test' });
+      expect(server.emitted()).toStrictEqual([output, output]);
     });
   });
 });

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,4 @@
-export interface RawEvent {
-  code: string;
-}
+import { RawEvent } from './raw-event';
 
 export interface InputEventCtor extends RawEvent {
   new(data: Object): InputEvent;

--- a/src/kafka/__tests__/kafka-consumer.test.ts
+++ b/src/kafka/__tests__/kafka-consumer.test.ts
@@ -4,6 +4,7 @@ import { testRouter } from '../../test/factories/test-router';
 import { testMessage } from '../../test/factories/test-message';
 import { testInvalidMessage } from '../../test/factories/test-invalid-message';
 import { configurationManager } from '../../test/factories/configurations';
+import { eventEmitted } from '../../test/emitter-helpers';
 
 describe('KafkaConsumer', () => {
   let consumer: EventConsumer;
@@ -13,32 +14,35 @@ describe('KafkaConsumer', () => {
     consumer.start();
   });
 
-  it('process a message', () => {
-    const emitted = new Promise((resolve, reject) => {
-      consumer.on('next', resolve);
-      consumer.on('error', reject);
-    });
-    kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testMessage());
-    return expect(emitted).resolves.toBeUndefined();
+  it('process a message', async () => {
+    const emitted = jest.fn();
+    consumer.on('next', emitted);
+    const message = testMessage();
+    kafkaNode.spies.trigger('ConsumerGroupStream', 'data', message);
+    await eventEmitted(consumer, 'next');
+    expect(emitted).toBeCalledWith(message);
   });
 
-  it('ignores invalid messages', () => {
-    const emitted = new Promise((resolve, reject) => {
-      consumer.on('next', resolve);
-      consumer.on('error', reject);
-    });
+  it('ignores invalid messages', async () => {
+    const emitted = jest.fn();
+    consumer.on('next', emitted);
+    const message = testMessage();
     kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testInvalidMessage());
-    kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testMessage());
-    return expect(emitted).resolves.toBeUndefined();
+    kafkaNode.spies.trigger('ConsumerGroupStream', 'data', message);
+    await eventEmitted(consumer, 'next');
+    expect(emitted).toHaveBeenCalledWith(message);
   });
 
-  it('emits errors on errors', () => {
-    const emitted = new Promise((resolve, reject) => {
-      consumer.on('next', resolve);
-      consumer.on('error', reject);
-    });
+  it('emits errors on errors', async () => {
+    const error = jest.fn();
+    const next = jest.fn();
+    consumer.on('next', next);
+    consumer.on('error', error);
+
     kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testMessage('throw'));
     kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testMessage());
-    return expect(emitted).rejects.toThrowError(/Test Error/);
+    await eventEmitted(consumer, 'error');
+    expect(next).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
   });
 });

--- a/src/kafka/__tests__/kafka-consumer.test.ts
+++ b/src/kafka/__tests__/kafka-consumer.test.ts
@@ -23,11 +23,10 @@ describe('KafkaConsumer', () => {
     expect(emitted).toBeCalledWith(message);
   });
 
-  it('ignores invalid messages', async () => {
+  it('lets invalid messages pass through', async () => {
     const emitted = jest.fn();
     consumer.on('next', emitted);
-    const message = testMessage();
-    kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testInvalidMessage());
+    const message = testInvalidMessage();
     kafkaNode.spies.trigger('ConsumerGroupStream', 'data', message);
     await eventEmitted(consumer, 'next');
     expect(emitted).toHaveBeenCalledWith(message);

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -1,9 +1,9 @@
 import { fromEvent, GroupedObservable } from 'rxjs';
-import { map, groupBy, tap, flatMap, filter } from 'rxjs/operators';
+import { map, groupBy, tap, flatMap } from 'rxjs/operators';
 import { ConsumerGroupStream, Message } from 'kafka-node';
 import { Router } from '../router';
 import { EventEmitter } from 'events';
-import { RawEvent } from '../events';
+import { RawEvent } from '../raw-event';
 import { messageTracer } from '../lib/message-tracer';
 import { EventMessage } from './interfaces/event-message';
 import { ConfigurationManager } from './configuration-manager';
@@ -56,7 +56,6 @@ export class EventConsumer extends EventEmitter {
 
     return partition.pipe(
       this.buildEvent(),
-      this.filterEvents(),
       this.log('Consuming'),
       this.router.route(trace),
       this.log('Committing'),
@@ -67,11 +66,6 @@ export class EventConsumer extends EventEmitter {
   private buildEvent() {
     return map((message: Message) =>
       ({ message, event: this.parseEvent(message.value.toString()) }));
-  }
-
-  private filterEvents() {
-    return filter(({ event: { code } }: EventMessage) =>
-      this.router.canRoute(code));
   }
 
   private log(message: string) {

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -27,7 +27,7 @@ export class EventConsumer extends EventEmitter {
       map(partition => this.handlePartition(partition)),
       flatMap(partition => partition)
     ).subscribe(
-      () => this.emit('next'),
+      ({ message }) => this.emit('next', message),
       (error) => { this.emit('error', error); }
     );
     this.consumerStream.resume();

--- a/src/kafka/interfaces/event-message.ts
+++ b/src/kafka/interfaces/event-message.ts
@@ -1,4 +1,4 @@
-import { RawEvent } from '../../events';
+import { RawEvent } from '../../raw-event';
 import { Message } from 'kafka-node';
 
 export interface EventMessage {

--- a/src/raw-event.ts
+++ b/src/raw-event.ts
@@ -1,0 +1,9 @@
+export class RawEvent {
+  code: string;
+
+  static isValid(obj: any): obj is RawEvent {
+    return typeof obj === 'object'
+      && typeof obj.code === 'string'
+      && obj.code !== '';
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,13 +6,14 @@ import { Observable, OperatorFunction } from 'rxjs';
 import { EventMessage } from './kafka/interfaces/event-message';
 import { map, concatMap, groupBy, flatMap } from 'rxjs/operators';
 import { FutureResult } from './kafka/interfaces/future-result';
+import { Message } from 'kafka-node';
 
 export const enum RouteStrategy {
   PARALLEL_ROUTE_PARALLEL_DISPATCH,
   PARALLEL_ROUTE_SEQUENTIAL_DISPATCH,
   SEQUENTIAL_ROUTE
 }
-type RouteResult = OperatorFunction <EventMessage, EventMessage>;
+type RouteResult = OperatorFunction<EventMessage, {message: Message}>;
 
 export class Router {
   public strategy = RouteStrategy.PARALLEL_ROUTE_PARALLEL_DISPATCH;

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,5 +1,6 @@
 import { Server } from './server';
-import { RawEvent, OutputEvent, InputEvent } from './events';
+import { OutputEvent, InputEvent } from './events';
+import { RawEvent } from './raw-event';
 import { Router } from './router';
 import { from } from 'rxjs';
 import { EventMessage } from './kafka/interfaces/event-message';

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -2,39 +2,50 @@ import { Server } from './server';
 import { OutputEvent, InputEvent } from './events';
 import { RawEvent } from './raw-event';
 import { Router } from './router';
-import { from } from 'rxjs';
+import { Subject } from 'rxjs';
 import { EventMessage } from './kafka/interfaces/event-message';
-import { map } from 'rxjs/operators';
+import { Message } from 'kafka-node';
+import { EventEmitter } from 'events';
 
-const rawToEventMessage = (event: RawEvent): EventMessage => ({
-  event,
-  message: { topic: 'test', value: JSON.stringify(event) }
-});
+const rawToEventMessage = (() => {
+  let offset = 0;
+  return (event: RawEvent): EventMessage => ({
+    event,
+    message: { offset: offset += 1, topic: 'test', value: JSON.stringify(event) }
+  });
+})();
 
 export class TestServer extends Server {
   private outputEvents: OutputEvent[] = [];
-  private rawEvents: RawEvent[] = [];
+  private subject: Subject<EventMessage> = new Subject();
+  private emitter = new EventEmitter();
 
   constructor(
     private router: Router
   ) {
     super(router);
+    this.subject.pipe(
+      this.router.route(v => v)
+    ).subscribe(
+      next => this.emitter.emit('next', next)
+    );
   }
 
-  input<T extends RawEvent>(event: T) {
-    this.rawEvents.push(event);
+  input<T extends RawEvent>(event: T): Promise<Message> {
+    const eventMessage = rawToEventMessage(event);
+    return new Promise((resolve) => {
+      this.emitter.on('next', ({ message }: { message: Message }) => {
+        if (message.offset === eventMessage.message.offset) resolve(message);
+      });
+      this.subject.next(eventMessage);
+    });
   }
 
   async output(event: OutputEvent): Promise<void> {
-    this.outputEvents.push(event);
+    this.outputEvents = this.outputEvents.concat(event);
   }
 
-  async emitted(): Promise<OutputEvent[]> {
-    await from(this.rawEvents).pipe(
-      map(rawToEventMessage),
-      this.router.route(v => v)
-    ).toPromise();
-
+  emitted(): OutputEvent[] {
     return this.outputEvents;
   }
 }

--- a/src/test/emitter-helpers.ts
+++ b/src/test/emitter-helpers.ts
@@ -1,4 +1,9 @@
 import { fail } from 'assert';
+import { EventEmitter } from 'events';
+
+export const eventEmitted = (emitter: EventEmitter, event: string) => {
+  return new Promise(resolve => emitter.on(event, resolve));
+};
 
 export const emitterHelper = () => {
   const listeners = new Map<string, Map<string, Function[]>>();


### PR DESCRIPTION
## Purpose

Commit unhandled events to prevent consumer groups to lag behind, and improve the TestServer 
implementation.

## Solution Approach

Refactor the Router and change it's implementation to allow passthrough of unhandled events and eventual committing of those events on the consumer. Use an event emitter to allow returning a promise on the `TestServer.input` method that's resolved when the generated event goes through the router.
