### PR TITLE
Fix action emit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,7 +10,7 @@ export abstract class Action {
 
   abstract perform(event: InputEvent): Promise<any>;
 
-  protected emit(event: OutputEvent) {
-    this.server.output(event);
+  protected emit(event: OutputEvent): Promise<void> {
+    return this.server.output(event);
   }
 }


### PR DESCRIPTION
## Purpose

The `Action.emit` method should return `Promise<void>` instead of just `void`.
