### PR TITLE
Force commits even if there's a pending commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/kafka/event-consumer.ts
+++ b/src/kafka/event-consumer.ts
@@ -74,7 +74,8 @@ export class EventConsumer extends EventEmitter {
   }
 
   private commit() {
-    return tap(({ message }: EventMessage) => this.consumerStream.commit(message));
+    return tap(({ message }: EventMessage) =>
+      this.consumerStream.commit(message, true));
   }
 
   private parseEvent(json: string): RawEvent {


### PR DESCRIPTION
## Purpose

We've seen that commits seem to be stuck sometimes, and after that happens no new offsets are committed. This change will ignore pending commits and commit the latest specified offset.