### PR TITLE
Handle events backpressure to prevent out of memory errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/kafka/__tests__/kafka-consumer.test.ts
+++ b/src/kafka/__tests__/kafka-consumer.test.ts
@@ -47,14 +47,16 @@ describe('KafkaConsumer', () => {
   });
 
   it('keeps track of backpressure', async () => {
-    expect(consumer.backpressure).toEqual(0);
+    let backpressure = 0;
+    consumer.backpressure.subscribe(i => backpressure = i);
+    expect(backpressure).toEqual(0);
     kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testSlowMessage('test1', 100));
-    expect(consumer.backpressure).toEqual(1);
+    expect(backpressure).toEqual(1);
     kafkaNode.spies.trigger('ConsumerGroupStream', 'data', testSlowMessage('test2', 100));
-    expect(consumer.backpressure).toEqual(2);
+    expect(backpressure).toEqual(2);
     await eventEmitted(consumer, 'next');
-    expect(consumer.backpressure).toEqual(1);
+    expect(backpressure).toEqual(1);
     await eventEmitted(consumer, 'next');
-    expect(consumer.backpressure).toEqual(0);
+    expect(backpressure).toEqual(0);
   });
 });

--- a/src/kafka/configuration-manager.ts
+++ b/src/kafka/configuration-manager.ts
@@ -4,6 +4,7 @@ import {
 import { Configuration } from './interfaces/configuration';
 import { ConsumerConfig } from './interfaces/consumer-config';
 import { ProducerConfig } from './interfaces/producer-config';
+import { BackpressureConfig } from './interfaces/backpressure-config';
 
 export class ConfigurationManager {
   constructor(
@@ -21,6 +22,14 @@ export class ConfigurationManager {
       ssl: get('ssl'),
       sslOptions: get('sslOptions'),
       sasl: get('sasl')
+    };
+  }
+
+  get backpressureOptions(): BackpressureConfig {
+    const get = this.getter(this.config.consumer);
+    return {
+      pause: (get<BackpressureConfig>('backpressure') || /* istanbul ignore next */{}).pause,
+      resume: (get<BackpressureConfig>('backpressure') || /* istanbul ignore next */{}).resume
     };
   }
 

--- a/src/kafka/interfaces/backpressure-config.ts
+++ b/src/kafka/interfaces/backpressure-config.ts
@@ -1,0 +1,4 @@
+export interface BackpressureConfig {
+  pause?: number;
+  resume?: number;
+}

--- a/src/kafka/interfaces/consumer-config.ts
+++ b/src/kafka/interfaces/consumer-config.ts
@@ -1,5 +1,7 @@
 import { GlobalConfig } from './global-config';
+import { BackpressureConfig } from './backpressure-config';
 export interface ConsumerConfig extends Partial<GlobalConfig> {
   groupId: string;
   topics: string[];
+  backpressure?: BackpressureConfig;
 }

--- a/src/test/factories/configurations.ts
+++ b/src/test/factories/configurations.ts
@@ -7,7 +7,11 @@ export const configuration: Configuration = {
   },
   consumer: {
     groupId: 'testGroupId',
-    topics: ['test-consumer-topic1', 'test-consumer-topic2']
+    topics: ['test-consumer-topic1', 'test-consumer-topic2'],
+    backpressure: {
+      pause: 3,
+      resume: 2
+    }
   },
   producer: {
     defaultTopic: 'test-producer-topic'


### PR DESCRIPTION
## Purpose

Currently reading a lot of events that take time to process might lead to out of memory errors due to accumulated unprocessed events waiting to be committed.
## Solution Approach

Backpressure is now handled by keeping track of the count of uncommitted events, and two new configuration options to control this were added (in consumer.backpressure), pause and resume. The consumer stream will pause upon reaching the pause limit and resume when it falls below the resume limit.