### PR TITLE
[IN-290] Retry produce on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/kafka/configuration-manager.ts
+++ b/src/kafka/configuration-manager.ts
@@ -5,6 +5,7 @@ import { Configuration } from './interfaces/configuration';
 import { ConsumerConfig } from './interfaces/consumer-config';
 import { ProducerConfig } from './interfaces/producer-config';
 import { BackpressureConfig } from './interfaces/backpressure-config';
+import { ProducerRetryOptions } from './interfaces/producer-retry-options';
 
 export class ConfigurationManager {
   constructor(
@@ -44,6 +45,15 @@ export class ConfigurationManager {
   get producerOptions(): ProducerOptions {
     return {
       partitionerType: this.config.producer.partitioner || 2
+    };
+  }
+
+  get retryOptions(): ProducerRetryOptions {
+    const options = this.config.producer.retry || { retries: 5, delay: 1000, increase: 2 };
+    return {
+      retries: options.retries,
+      delay: options.delay,
+      increase: options.increase
     };
   }
   private getter(elem: ConsumerConfig|ProducerConfig) {

--- a/src/kafka/interfaces/producer-config.ts
+++ b/src/kafka/interfaces/producer-config.ts
@@ -1,6 +1,8 @@
 import { GlobalConfig } from './global-config';
+import { ProducerRetryOptions } from './producer-retry-options';
 
 export interface ProducerConfig extends Partial<GlobalConfig> {
   defaultTopic: string;
   partitioner?: 0 | 1 | 2 | 3;
+  retry?: ProducerRetryOptions;
 }

--- a/src/kafka/interfaces/producer-retry-options.ts
+++ b/src/kafka/interfaces/producer-retry-options.ts
@@ -1,0 +1,5 @@
+export interface ProducerRetryOptions {
+  retries: number;
+  delay: number;
+  increase: number;
+}

--- a/src/lib/__tests__/retry.test.ts
+++ b/src/lib/__tests__/retry.test.ts
@@ -1,0 +1,38 @@
+import { of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { retry } from '../retry';
+import { fail } from 'assert';
+
+describe('Retry', () => {
+  const testErr = (failTimes = 3, result = true) => {
+    let count = 0;
+    return () => ((count += 1) < failTimes) ? fail(`Count: ${count}`) : result;
+  };
+
+  it('retries a failed observable', async () => {
+    const result = await of(1).pipe(
+      map(testErr()),
+      retry(2, 100, 1)
+    ).toPromise();
+    expect(result).toEqual(true);
+  });
+
+  it('fails after the expected retries', async () => {
+    const result = of(1).pipe(
+      map(testErr(4)),
+      retry(2, 100, 1)
+    ).toPromise();
+    await expect(result).rejects.toThrow(/Count: 3/);
+  });
+
+  it('waits the expected time', async () => {
+    const expected = 600;
+    const start = Date.now();
+    await of(1).pipe(
+      map(testErr(4)),
+      retry(3, 100, 2)
+    ).toPromise();
+    const end = Date.now();
+    await expect(expected - (end - start)).toBeLessThan(100);
+  });
+});

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,0 +1,13 @@
+import { Observable, throwError, timer } from 'rxjs';
+import { flatMap, retryWhen } from 'rxjs/operators';
+
+type Timer = (attempt: number) => Observable<number>;
+const retryStrategy = (retries: number, timer: Timer) => (obs: Observable<Error>) =>
+  obs.pipe(flatMap((error: Error, attempt: number) =>
+      attempt < retries ? timer(attempt) : throwError(error)
+  ));
+
+export const retry = <T>(retries: number, delay: number, increase: number) => {
+  const increasingTimer = (attempt: number) => timer(attempt * (increase - 1) * delay + delay);
+  return (obs: Observable<T>) => obs.pipe(retryWhen(retryStrategy(retries, increasingTimer)));
+};


### PR DESCRIPTION
## Purpose

A broker might be unavailable for just a couple of seconds and fail the produce method. This might be network/broker related and in most situations it's fixed pretty soon (Broker Unavailable errors)
## Solution Approach

The produce method will retry when it fails. Configurable in the producer options, default value: {retries: 5, delay: 1000, increase: 2}).