### PR TITLE
Add clean function for emitted events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/__tests__/test-helpers.test.ts
+++ b/src/__tests__/test-helpers.test.ts
@@ -27,5 +27,20 @@ describe('TestHelpers', () => {
       await server.input({ code: TestInputEvent.name, value: 'test' });
       expect(server.emitted()).toStrictEqual([output, output]);
     });
+
+    describe('cleanEmitted', () => {
+      it('should clean emitted events list', async () => {
+        const output = new TestOutputEvent();
+        TestOutputAction.outputEvent = output;
+
+        await server.input({ code: TestInputEvent.name, value: 'test' });
+        await server.input({ code: TestInputEvent.name, value: 'test' });
+        expect(server.emitted()).toStrictEqual([output, output]);
+
+        server.cleanEmitted();
+
+        expect(server.emitted().length).toBe(0);
+      });
+    });
   });
 });

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -48,6 +48,10 @@ export class TestServer extends Server {
   emitted(): OutputEvent[] {
     return this.outputEvents;
   }
+
+  cleanEmitted(): void {
+    this.outputEvents = [];
+  }
 }
 
 export class TestInputEvent extends InputEvent {


### PR DESCRIPTION
## Purpose

Add clean function for emitted events to be able to reuse the same TestServer instance instead of creating a new instance per test.

## Solution Approach

Add function that replace emitted events list with an empty array.

## Learning

Even if there a few solutions to clean an array, replacing it with an empty one looks like the most performant.
https://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
