### PR TITLE
feat: MC-2268 add disabled consumer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/kafka/configuration-manager.ts
+++ b/src/kafka/configuration-manager.ts
@@ -58,4 +58,9 @@ export class ConfigurationManager {
   private getter(elem: ConsumerConfig|ProducerConfig) {
     return <T>(property: string): T => elem[property] || this.config.global[property];
   }
+
+  get consumerEnabled() {
+    /* istanbul ignore next */
+    return this.config.consumer.hasOwnProperty('enabled') ? this.config.consumer.enabled : true;
+  }
 }

--- a/src/kafka/event-consumer/index.ts
+++ b/src/kafka/event-consumer/index.ts
@@ -26,6 +26,10 @@ export class EventConsumer extends EventEmitter {
   start(): void {
     const { pause, resume } = this.config.backpressureOptions;
     const { groupId } = this.config.consumerOptions;
+
+    /* istanbul ignore next */
+    if (!this.config.consumerEnabled) return;
+
     this.consumerStream = this.createStream();
     this.backpressureHandler = new BackpressureHandler(this.consumerStream, pause, resume);
     this.partitionHandler = new PartitionHandler(groupId, this.router);
@@ -35,6 +39,10 @@ export class EventConsumer extends EventEmitter {
 
   stop(): Promise<any> {
     return new Promise((resolve) => {
+      /* istanbul ignore next */
+      if (!this.config.consumerEnabled) {
+        return resolve('Consumer disabled');
+      }
       this.consumerStream.close(() => {
         resolve('Consumer disconnected');
       });

--- a/src/kafka/interfaces/consumer-config.ts
+++ b/src/kafka/interfaces/consumer-config.ts
@@ -4,4 +4,5 @@ export interface ConsumerConfig extends Partial<GlobalConfig> {
   groupId: string;
   topics: string[];
   backpressure?: BackpressureConfig;
+  enabled?: boolean;
 }


### PR DESCRIPTION
## Purpose

> event-streamer needs to be implemented in gcp functions, but every time a server is created, it creates a consumer.  and at the end of the functions the consumer connection will also be closed; This behavior can have a negative impact on kafka.

## Solution Approach

> Added configuration enabled to consumer to avoid unnecessary connections.
> Default consumer.enabled: true
