### PR TITLE
Rcabral/producer update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Event Streamer is a library for connect micro services based on kafka event comm
 
 This is a wrap of [kafka-node](https://www.npmjs.com/package/kafka-node) simplifying connection, errors and topic with subject (event name, event code).
 
+This library is not intended to consume two different clusters at the same time, but you can produce in two or more clusters at the same time.
+
 ## Installation
 
 yarn:
@@ -52,6 +54,7 @@ setConfig({
 | producer | Object | Object | *optional* |
 | producer.partitionerType | ProducerPartitionerType (number) | Choose how the producer will send the messages | *optional* <br/> default: CYCLIC (2) |
 | producer.additionalHosts | string[] | Additional hosts to send a message. This is useful if you need to send information to two or more different clusters | *optional* |
+| producer.connectionTTL | number | Time in ms that the connection will be keep open after last message was sent | *optional* <br/> default: 5000 |
 | producer.retryOptions | RetryOptions (Object) | kafka-node retry options: retries, factor, minTimeout, maxTimeout and randomize | *optional* |
 | consumer | Object | Object | *required to start consumer* |
 | consumer.groupId | string | Kafka group id | **required** |
@@ -81,7 +84,7 @@ If a subject is not provided then the topic will be transformed to UpperCamelCas
 
 ### Producing
 
-Event streamer will create and close kafka client on demand to avoid keeping open connections.
+Event streamer will create and close kafka client on demand to avoid keeping open connections, this connection will be reused until TTL is reached (TTL is renewed after each execution).
 Produced events will be delivered the `data` object into a single topic as JSON string with the corresponding subject.
 
 #### Single event

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -24,6 +24,8 @@ export interface Config {
   producer?: {
     /** Default is CYCLIC (2) */
     partitionerType?: ProducerPartitionerType;
+    /** Connection keep alive after send messages to reuse it. Default 5000 ms */
+    connectionTTL?: number;
     additionalHosts?: string[];
     retryOptions?: RetryOptions;
   };

--- a/src/producer/__tests__/index.test.ts
+++ b/src/producer/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { Producer } from 'kafka-node';
 import { clearEmittedEvents, emit, getEmittedEvents } from '..';
 import { setConfig } from '../../config';
 import { ProducerPartitionerType } from '../../interfaces';
+import { sleep } from '../../test/helpers';
 
 const defaultHeaderData = {
   attributes: 0,
@@ -18,7 +19,10 @@ describe('producer', () => {
   describe('emit success', () => {
     beforeEach(() => {
       setConfig({
-        host: 'kafka:9092'
+        host: 'kafka:9092',
+        producer: {
+          connectionTTL: 500
+        }
       });
     });
     it('Should emit a single event with different topic and code', async () => {
@@ -51,7 +55,7 @@ describe('producer', () => {
         ],
         expect.any(Function)
       );
-      expect(closeSpy).toHaveBeenCalled();
+      expect(closeSpy).not.toHaveBeenCalled();
 
       const topicsOffset = response.find((messages) => messages[defaultHeaderData.topic] != null);
       expect(topicsOffset).toBeDefined();
@@ -92,7 +96,7 @@ describe('producer', () => {
         ],
         expect.any(Function)
       );
-      expect(closeSpy).toHaveBeenCalled();
+      expect(closeSpy).not.toHaveBeenCalled();
       sendSpy.mockClear();
     });
 
@@ -140,7 +144,7 @@ describe('producer', () => {
         ],
         expect.any(Function)
       );
-      expect(closeSpy).toHaveBeenCalled();
+      expect(closeSpy).not.toHaveBeenCalled();
       sendSpy.mockClear();
     });
 
@@ -195,6 +199,7 @@ describe('producer', () => {
         ],
         expect.any(Function)
       );
+      await sleep(600);
       expect(closeSpy).toHaveBeenCalled();
       sendSpy.mockClear();
     });


### PR DESCRIPTION
## Purpose

> Reuse producer connection to avoid multi production lag

## Solution Approach

> Keep producers per host into a separated object and let a timer that will delete it after 5000 ms (default)
