### PR TITLE
Add Promise<void> as possible response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/event-streamer",
-  "version": "8.2.4",
+  "version": "8.2.5",
   "description": "Simple event-streaming framework",
   "repository": "comparaonline/event-streamer",
   "author": {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -60,7 +60,7 @@ export interface Input {
   code?: string;
 }
 
-export type Callback<T extends Input> = (input: T, emit: (message: Output) => Promise<any>) => void;
+export type Callback<T extends Input> = (input: T, emit: (message: Output) => Promise<any>) => Promise<void> | void;
 
 export interface Route {
   topic: string;


### PR DESCRIPTION
## Purpose
Allow functions with type Promise<void> as possible response.
Avoid conflicts with the following rule:
`Promise returned in function argument where a void return was expected. (@typescript-eslint/no-misused-promises`